### PR TITLE
Add `matches` and `closest` functions to Web.DOM.Element.

### DIFF
--- a/src/Web/DOM/Element.js
+++ b/src/Web/DOM/Element.js
@@ -168,3 +168,19 @@ exports.clientHeight = function (el) {
     return el.clientHeight;
   };
 };
+
+exports.matches = function (selector) {
+  return function(el) {
+    return function() {
+      return el.matches(selector);
+    };
+  };
+};
+
+exports._closest = function (selector) {
+  return function(el) {
+    return function() {
+      return el.closest(selector);
+    };
+  };
+};

--- a/src/Web/DOM/Element.purs
+++ b/src/Web/DOM/Element.purs
@@ -35,6 +35,8 @@ module Web.DOM.Element
   , clientLeft
   , clientWidth
   , clientHeight
+  , matches
+  , closest
   ) where
 
 import Prelude
@@ -127,3 +129,10 @@ foreign import clientTop :: Element -> Effect Number
 foreign import clientLeft :: Element -> Effect Number
 foreign import clientWidth :: Element -> Effect Number
 foreign import clientHeight :: Element -> Effect Number
+
+foreign import matches :: String -> Element -> Effect Boolean
+
+foreign import _closest :: String -> Element -> Effect (Nullable Element)
+
+closest :: String -> Element -> Effect (Maybe Element)
+closest selector = map toMaybe <<< _closest selector


### PR DESCRIPTION
Hi @garyb, these functions are documented here:

1. https://developer.mozilla.org/en-US/docs/Web/API/Element/matches
2. https://developer.mozilla.org/en-US/docs/Web/API/Element/closest

`closest` is marked as "experimental" but it's present in the [DOM Living Standard](https://dom.spec.whatwg.org/#dom-element-closest).

I'm not sure what your policy is on functions not supported by all browsers but I needed this in something I'm working on so I thought I'd send a PR for you to review.