### PR TITLE
Add scroll, scrollTo, scrollBy, scrollIntoView

### DIFF
--- a/src/Web/DOM/Element.js
+++ b/src/Web/DOM/Element.js
@@ -133,6 +133,42 @@ exports.setScrollLeft = function (scrollLeft) {
   };
 };
 
+exports._scroll = function (scrollToOptions) {
+  return function (node) {
+    return function () {
+      node.scroll(scrollToOptions);
+      return {};
+    };
+  };
+};
+
+exports._scrollTo = function (scrollToOptions) {
+  return function (node) {
+    return function () {
+      node.scrollTo(scrollToOptions);
+      return {};
+    };
+  };
+};
+
+exports._scrollBy = function (scrollToOptions) {
+  return function (node) {
+    return function () {
+      node.scrollBy(scrollToOptions);
+      return {};
+    };
+  };
+};
+
+exports._scrollIntoView = function (scrollIntoViewOptions) {
+  return function (node) {
+    return function () {
+      node.scrollIntoView(scrollIntoViewOptions);
+      return {};
+    };
+  };
+};
+
 exports.scrollWidth = function (el) {
   return function () {
     return el.scrollWidth;

--- a/src/Web/DOM/Element.purs
+++ b/src/Web/DOM/Element.purs
@@ -30,8 +30,8 @@ module Web.DOM.Element
   , scrollLeft
   , setScrollLeft
   , ScrollToOptions
-  , ScrollBehavior
-  , ScrollAlignment
+  , ScrollBehavior(..)
+  , ScrollAlignment(..)
   , scroll
   , scrollTo
   , scrollBy

--- a/src/Web/DOM/Element.purs
+++ b/src/Web/DOM/Element.purs
@@ -147,20 +147,20 @@ type ScrollToOptions_ =
   , behavior :: String
   }
 
-foreign import _scroll :: Element -> ScrollToOptions_ -> Effect Unit
+foreign import _scroll :: ScrollToOptions_ -> Element -> Effect Unit
 
-scroll :: Element -> ScrollToOptions -> Effect Unit
-scroll elem opts = _scroll elem (opts { behavior = stringScrollBehavior opts.behavior })
+scroll :: ScrollToOptions -> Element -> Effect Unit
+scroll opts = _scroll (opts { behavior = stringScrollBehavior opts.behavior })
 
-foreign import _scrollTo :: Element -> ScrollToOptions_ -> Effect Unit
+foreign import _scrollTo :: ScrollToOptions_ -> Element -> Effect Unit
 
-scrollTo :: Element -> ScrollToOptions -> Effect Unit
-scrollTo elem opts = _scrollTo elem (opts { behavior = stringScrollBehavior opts.behavior })
+scrollTo :: ScrollToOptions -> Element -> Effect Unit
+scrollTo opts = _scrollTo (opts { behavior = stringScrollBehavior opts.behavior })
 
-foreign import _scrollBy :: Element -> ScrollToOptions_ -> Effect Unit
+foreign import _scrollBy :: ScrollToOptions_ -> Element -> Effect Unit
 
-scrollBy :: Element -> ScrollToOptions -> Effect Unit
-scrollBy elem opts = _scrollBy elem (opts { behavior = stringScrollBehavior opts.behavior })
+scrollBy :: ScrollToOptions -> Element -> Effect Unit
+scrollBy opts = _scrollBy (opts { behavior = stringScrollBehavior opts.behavior })
 
 data ScrollAlignment = Start | Center | End | Nearest
 
@@ -182,10 +182,10 @@ type ScrollIntoViewOptions_ =
   , inline :: String
   }
 
-foreign import _scrollIntoView :: Element -> ScrollIntoViewOptions_ -> Effect Unit
+foreign import _scrollIntoView :: ScrollIntoViewOptions_ -> Element -> Effect Unit
 
-scrollIntoView :: Element -> ScrollIntoViewOptions -> Effect Unit
-scrollIntoView elem _opts = _scrollIntoView elem opts
+scrollIntoView :: ScrollIntoViewOptions -> Element -> Effect Unit
+scrollIntoView _opts = _scrollIntoView opts
   where
     opts = { behavior: stringScrollBehavior _opts.behavior
            , block: stringScrollAlignment _opts.block

--- a/src/Web/DOM/Element.purs
+++ b/src/Web/DOM/Element.purs
@@ -150,26 +150,17 @@ type ScrollToOptions_ =
 foreign import _scroll :: Element -> ScrollToOptions_ -> Effect Unit
 
 scroll :: Element -> ScrollToOptions -> Effect Unit
-scroll elem _opts = _scroll elem opts
-  where
-    opts = let { top,left, behavior } = _opts
-           in { top, left, behavior: stringScrollBehavior behavior }
+scroll elem opts = _scroll elem (opts { behavior = stringScrollBehavior opts.behavior })
 
 foreign import _scrollTo :: Element -> ScrollToOptions_ -> Effect Unit
 
 scrollTo :: Element -> ScrollToOptions -> Effect Unit
-scrollTo elem _opts = _scrollTo elem opts
-  where
-    opts = let { top,left, behavior } = _opts
-           in { top, left, behavior: stringScrollBehavior behavior }
+scrollTo elem opts = _scrollTo elem (opts { behavior = stringScrollBehavior opts.behavior })
 
 foreign import _scrollBy :: Element -> ScrollToOptions_ -> Effect Unit
 
 scrollBy :: Element -> ScrollToOptions -> Effect Unit
-scrollBy elem _opts = _scrollBy elem opts
-  where
-    opts = let { top,left, behavior } = _opts
-           in { top, left, behavior: stringScrollBehavior behavior }
+scrollBy elem opts = _scrollBy elem (opts { behavior = stringScrollBehavior opts.behavior })
 
 data ScrollAlignment = Start | Center | End | Nearest
 
@@ -196,11 +187,10 @@ foreign import _scrollIntoView :: Element -> ScrollIntoViewOptions_ -> Effect Un
 scrollIntoView :: Element -> ScrollIntoViewOptions -> Effect Unit
 scrollIntoView elem _opts = _scrollIntoView elem opts
   where
-    opts = let { behavior, block, inline } = _opts
-            in { behavior: stringScrollBehavior behavior
-               , block: stringScrollAlignment block
-               , inline: stringScrollAlignment inline
-               }
+    opts = { behavior: stringScrollBehavior _opts.behavior
+           , block: stringScrollAlignment _opts.block
+           , inline: stringScrollAlignment _opts.inline
+           }
 
 foreign import scrollWidth :: Element -> Effect Number
 foreign import scrollHeight :: Element -> Effect Number

--- a/src/Web/DOM/Element.purs
+++ b/src/Web/DOM/Element.purs
@@ -29,6 +29,14 @@ module Web.DOM.Element
   , setScrollTop
   , scrollLeft
   , setScrollLeft
+  , ScrollToOptions
+  , ScrollBehavior
+  , ScrollAlignment
+  , scroll
+  , scrollTo
+  , scrollBy
+  , ScrollIntoViewOptions
+  , scrollIntoView
   , scrollWidth
   , scrollHeight
   , clientTop
@@ -120,6 +128,79 @@ foreign import setScrollTop :: Number -> Element -> Effect Unit
 
 foreign import scrollLeft :: Element -> Effect Number
 foreign import setScrollLeft :: Number -> Element -> Effect Unit
+
+data ScrollBehavior = Auto | Smooth
+
+stringScrollBehavior :: ScrollBehavior -> String
+stringScrollBehavior Auto = "auto"
+stringScrollBehavior Smooth = "smooth"
+
+type ScrollToOptions =
+  { top :: Number
+  , left :: Number
+  , behavior :: ScrollBehavior
+  }
+
+type ScrollToOptions_ =
+  { top :: Number
+  , left :: Number
+  , behavior :: String
+  }
+
+foreign import _scroll :: Element -> ScrollToOptions_ -> Effect Unit
+
+scroll :: Element -> ScrollToOptions -> Effect Unit
+scroll elem _opts = _scroll elem opts
+  where
+    opts = let { top,left, behavior } = _opts
+           in { top, left, behavior: stringScrollBehavior behavior }
+
+foreign import _scrollTo :: Element -> ScrollToOptions_ -> Effect Unit
+
+scrollTo :: Element -> ScrollToOptions -> Effect Unit
+scrollTo elem _opts = _scrollTo elem opts
+  where
+    opts = let { top,left, behavior } = _opts
+           in { top, left, behavior: stringScrollBehavior behavior }
+
+foreign import _scrollBy :: Element -> ScrollToOptions_ -> Effect Unit
+
+scrollBy :: Element -> ScrollToOptions -> Effect Unit
+scrollBy elem _opts = _scrollBy elem opts
+  where
+    opts = let { top,left, behavior } = _opts
+           in { top, left, behavior: stringScrollBehavior behavior }
+
+data ScrollAlignment = Start | Center | End | Nearest
+
+stringScrollAlignment :: ScrollAlignment -> String
+stringScrollAlignment Start = "start"
+stringScrollAlignment Center = "center"
+stringScrollAlignment End = "end"
+stringScrollAlignment Nearest = "nearest"
+
+type ScrollIntoViewOptions =
+  { behavior :: ScrollBehavior
+  , block :: ScrollAlignment
+  , inline :: ScrollAlignment
+  }
+
+type ScrollIntoViewOptions_ =
+  { behavior :: String
+  , block :: String
+  , inline :: String
+  }
+
+foreign import _scrollIntoView :: Element -> ScrollIntoViewOptions_ -> Effect Unit
+
+scrollIntoView :: Element -> ScrollIntoViewOptions -> Effect Unit
+scrollIntoView elem _opts = _scrollIntoView elem opts
+  where
+    opts = let { behavior, block, inline } = _opts
+            in { behavior: stringScrollBehavior behavior
+               , block: stringScrollAlignment block
+               , inline: stringScrollAlignment inline
+               }
 
 foreign import scrollWidth :: Element -> Effect Number
 foreign import scrollHeight :: Element -> Effect Number


### PR DESCRIPTION
We add [`Element.scroll`][1], [`Element.scrollTo`][2],
[`Element.scrollBy`][3], and [`Element.scrollIntoView`][4].

[1]: https://developer.mozilla.org/en-US/docs/Web/API/Element/scroll
[2]: https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTo
[3]: https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollBy
[4]: https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView

---

There are more missing methods but this is a start, and what I personally need at the moment. We can also re-export `scroll`, `scrollTo`, and `scrollBy` with `unsafeCoerce` from `Window -> Element` in `purescript-web-html`.