### PR TITLE
add innerHTML and innerText for Element

### DIFF
--- a/src/Web/DOM/Element.js
+++ b/src/Web/DOM/Element.js
@@ -105,6 +105,34 @@ exports.removeAttribute = function (name) {
   };
 };
 
+exports.innerHTML = function (node) {
+  return function () {
+    return node.innerHTML;
+  };
+};
+
+exports.setInnerHTML = function (innerHTML) {
+  return function (node) {
+    return function () {
+      node.innerHTML = innerHTML;
+    };
+  };
+};
+
+exports.innerText = function (node) {
+  return function () {
+    return node.innerText;
+  };
+};
+
+exports.setInnerText = function (innerText) {
+  return function (node) {
+    return function () {
+      node.innerText = innerText;
+    };
+  };
+};
+
 // - CSSOM ---------------------------------------------------------------------
 
 exports.scrollTop = function (node) {

--- a/src/Web/DOM/Element.purs
+++ b/src/Web/DOM/Element.purs
@@ -26,6 +26,10 @@ module Web.DOM.Element
   , getAttribute
   , hasAttribute
   , removeAttribute
+  , innerHTML
+  , setInnerHTML
+  , innerText
+  , setInnerText
   , scrollTop
   , setScrollTop
   , scrollLeft
@@ -117,6 +121,12 @@ getAttribute attr = map toMaybe <<< _getAttribute attr
 foreign import _getAttribute :: String -> Element -> Effect (Nullable String)
 foreign import hasAttribute :: String -> Element -> Effect Boolean
 foreign import removeAttribute :: String -> Element -> Effect Unit
+
+foreign import innerHTML :: Element -> Effect String
+foreign import setInnerHTML :: String -> Element -> Effect Unit
+
+foreign import innerText :: Element -> Effect String
+foreign import setInnerText :: String -> Element -> Effect Unit
 
 foreign import scrollTop :: Element -> Effect Number
 foreign import setScrollTop :: Number -> Element -> Effect Unit


### PR DESCRIPTION
`innerHTML` and `innerText` can't be accessed through attributes. It would be natural to add corresponding functions to `Web.DOM.Element`. I can do PR, but I'm not sure how it would fit in here.

Proposed functions are:
```purescript
innerHTML :: Element -> Effect String
setInnerHTML :: String -> Element -> Effect String

innerText :: Element -> Effect String
setInnerText :: String -> Element -> Effect String
```