### PR TITLE
Add ShadowRoot module

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: purescript-contrib/setup-purescript@main
+        with:
+          purescript: "0.14.0-rc3"
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "10"
+
+      - name: Install dependencies
+        run: |
+          npm install -g bower
+          npm install
+          bower install --production
+
+      - name: Build source
+        run: npm run-script build
+
+      - name: Run tests
+        run: |
+          bower install
+          npm run-script test --if-present

--- a/src/Web/DOM/ShadowRoot.js
+++ b/src/Web/DOM/ShadowRoot.js
@@ -1,0 +1,19 @@
+"use strict";
+
+exports._attachShadow = function(props) {
+  return function (el) {
+    return function() {
+      return el.attachShadow(props);
+    };
+  };
+};
+
+exports._mode = function (el) {
+  return el.mode;
+};
+
+exports.host = function (el) {
+  return function() {
+    return el.host;
+  };
+};

--- a/src/Web/DOM/ShadowRoot.purs
+++ b/src/Web/DOM/ShadowRoot.purs
@@ -1,0 +1,47 @@
+module Web.DOM.ShadowRoot
+  ( ShadowRoot
+  , ShadowRootMode (..)
+  , attachShadow
+  , host
+  , mode
+  , toNode
+  ) where
+
+import Prelude
+import Data.Maybe (Maybe(..))
+import Effect (Effect)
+import Unsafe.Coerce (unsafeCoerce)
+import Web.DOM.Internal.Types (Element, Node)
+
+foreign import data ShadowRoot :: Type
+
+data ShadowRootMode = Open | Closed
+
+instance showShadowRootMode :: Show ShadowRootMode where
+  show Open = "open"
+  show Closed = "closed"
+
+attachShadow :: ShadowRootMode -> Element -> Effect ShadowRoot
+attachShadow = _attachShadow <<< modeToProps
+
+mode :: ShadowRoot -> Maybe ShadowRootMode
+mode = modeFromString <<< _mode
+
+foreign import host :: ShadowRoot -> Effect Element
+
+toNode :: ShadowRoot -> Node
+toNode = unsafeCoerce
+
+type ShadowRootProps = { mode :: String }
+
+foreign import _attachShadow :: ShadowRootProps -> Element -> Effect ShadowRoot
+foreign import _mode :: ShadowRoot -> String
+
+modeToProps :: ShadowRootMode -> ShadowRootProps
+modeToProps m = { mode: (show m) }
+
+modeFromString :: String -> Maybe ShadowRootMode
+modeFromString m = case m of
+  "open" -> Just Open
+  "closed" -> Just Closed
+  _ -> Nothing


### PR DESCRIPTION
### Description
Basic implementation of the shadow-root functionality, as per [DOM standard](https://dom.spec.whatwg.org/#interface-shadowroot).
The function `attachShadow` is a binding to the corresponding DOM JavaScript function described
on [MDN](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM).
