### PR TITLE
Add support for ShadowRoot API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: purescript-contrib/setup-purescript@main
         with:
-          purescript: "0.14.0-rc3"
+          purescript: "0.14.0-rc5"
 
       - uses: actions/setup-node@v1
         with:

--- a/src/Web/DOM/Element.js
+++ b/src/Web/DOM/Element.js
@@ -170,3 +170,11 @@ exports.clientHeight = function (el) {
     return el.clientHeight;
   };
 };
+
+exports._attachShadow = function(props) {
+  return function (el) {
+    return function() {
+      return el.attachShadow(props);
+    };
+  };
+};

--- a/src/Web/DOM/Element.purs
+++ b/src/Web/DOM/Element.purs
@@ -36,6 +36,8 @@ module Web.DOM.Element
   , clientLeft
   , clientWidth
   , clientHeight
+  , ShadowRootInit
+  , attachShadow
   ) where
 
 import Prelude
@@ -50,6 +52,7 @@ import Web.DOM.Internal.Types (Element) as Exports
 import Web.DOM.Internal.Types (Element, HTMLCollection, Node)
 import Web.DOM.NonDocumentTypeChildNode (NonDocumentTypeChildNode)
 import Web.DOM.ParentNode (ParentNode)
+import Web.DOM.ShadowRoot (ShadowRoot, ShadowRootMode)
 import Web.Event.EventTarget (EventTarget)
 import Web.Internal.FFI (unsafeReadProtoTagged)
 
@@ -130,3 +133,24 @@ foreign import clientTop :: Element -> Effect Number
 foreign import clientLeft :: Element -> Effect Number
 foreign import clientWidth :: Element -> Effect Number
 foreign import clientHeight :: Element -> Effect Number
+
+type ShadowRootInit = {
+  mode :: ShadowRootMode,
+  delegatesFocus :: Boolean
+}
+
+type ShadowRootProps = {
+  mode :: String,
+  delegatesFocus :: Boolean
+}
+
+attachShadow :: ShadowRootInit -> Element -> Effect ShadowRoot
+attachShadow = _attachShadow <<< initToProps
+
+initToProps :: ShadowRootInit -> ShadowRootProps
+initToProps init = {
+  mode: show init.mode,
+  delegatesFocus: init.delegatesFocus
+}
+
+foreign import _attachShadow :: ShadowRootProps -> Element -> Effect ShadowRoot

--- a/src/Web/DOM/Element.purs
+++ b/src/Web/DOM/Element.purs
@@ -139,13 +139,13 @@ type ShadowRootInit = {
   delegatesFocus :: Boolean
 }
 
+attachShadow :: ShadowRootInit -> Element -> Effect ShadowRoot
+attachShadow = _attachShadow <<< initToProps
+
 type ShadowRootProps = {
   mode :: String,
   delegatesFocus :: Boolean
 }
-
-attachShadow :: ShadowRootInit -> Element -> Effect ShadowRoot
-attachShadow = _attachShadow <<< initToProps
 
 initToProps :: ShadowRootInit -> ShadowRootProps
 initToProps init = {

--- a/src/Web/DOM/ShadowRoot.js
+++ b/src/Web/DOM/ShadowRoot.js
@@ -1,0 +1,19 @@
+"use strict";
+
+exports._attachShadow = function(props) {
+  return function (el) {
+    return function() {
+      return el.attachShadow(props);
+    };
+  };
+};
+
+exports._mode = function (el) {
+  return el.mode;
+};
+
+exports.host = function (el) {
+  return function() {
+    return el.host;
+  };
+};

--- a/src/Web/DOM/ShadowRoot.js
+++ b/src/Web/DOM/ShadowRoot.js
@@ -1,13 +1,5 @@
 "use strict";
 
-exports._attachShadow = function(props) {
-  return function (el) {
-    return function() {
-      return el.attachShadow(props);
-    };
-  };
-};
-
 exports._mode = function (el) {
   return el.mode;
 };

--- a/src/Web/DOM/ShadowRoot.purs
+++ b/src/Web/DOM/ShadowRoot.purs
@@ -1,0 +1,47 @@
+module Web.DOM.ShadowRoot
+  ( ShadowRoot
+  , ShadowRootMode (..)
+  , attachShadow
+  , host
+  , mode
+  , toNode
+  ) where
+
+import Prelude
+import Data.Maybe (Maybe(..))
+import Effect (Effect)
+import Unsafe.Coerce (unsafeCoerce)
+import Web.DOM.Internal.Types (Element, Node)
+
+foreign import data ShadowRoot :: Type
+
+data ShadowRootMode = Open | Closed
+
+instance showShadowRootMode :: Show ShadowRootMode where
+  show Open = "open"
+  show Closed = "closed"
+
+attachShadow :: ShadowRootMode -> Element -> Effect ShadowRoot
+attachShadow = _attachShadow <<< modeToProps
+
+mode :: ShadowRoot -> Maybe ShadowRootMode
+mode = modeFromString <<< _mode
+
+foreign import host :: ShadowRoot -> Effect Element
+
+toNode :: ShadowRoot -> Node
+toNode = unsafeCoerce
+
+type ShadowRootProps = { mode :: String }
+
+foreign import _attachShadow :: ShadowRootProps -> Element -> Effect ShadowRoot
+foreign import _mode :: ShadowRoot -> String
+
+modeToProps :: ShadowRootMode -> ShadowRootProps
+modeToProps m = { mode: (show m) }
+
+modeFromString :: String -> Maybe ShadowRootMode
+modeFromString m = case m of
+  "open" -> Just Open
+  "closed" -> Just Closed
+  _ -> Nothing

--- a/src/Web/DOM/ShadowRoot.purs
+++ b/src/Web/DOM/ShadowRoot.purs
@@ -1,9 +1,9 @@
 module Web.DOM.ShadowRoot
   ( ShadowRoot
   , ShadowRootMode (..)
+  , toNode
   , host
   , mode
-  , toNode
   ) where
 
 import Prelude
@@ -14,6 +14,9 @@ import Web.DOM.Internal.Types (Element, Node)
 
 foreign import data ShadowRoot :: Type
 
+toNode :: ShadowRoot -> Node
+toNode = unsafeCoerce
+
 data ShadowRootMode = Open | Closed
 
 instance showShadowRootMode :: Show ShadowRootMode where
@@ -22,16 +25,11 @@ instance showShadowRootMode :: Show ShadowRootMode where
 
 mode :: ShadowRoot -> Maybe ShadowRootMode
 mode = modeFromString <<< _mode
+  where
+    modeFromString = case _ of
+      "open" -> Just Open
+      "closed" -> Just Closed
+      _ -> Nothing
 
 foreign import host :: ShadowRoot -> Effect Element
-
-toNode :: ShadowRoot -> Node
-toNode = unsafeCoerce
-
 foreign import _mode :: ShadowRoot -> String
-
-modeFromString :: String -> Maybe ShadowRootMode
-modeFromString m = case m of
-  "open" -> Just Open
-  "closed" -> Just Closed
-  _ -> Nothing

--- a/src/Web/DOM/ShadowRoot.purs
+++ b/src/Web/DOM/ShadowRoot.purs
@@ -1,7 +1,6 @@
 module Web.DOM.ShadowRoot
   ( ShadowRoot
   , ShadowRootMode (..)
-  , attachShadow
   , host
   , mode
   , toNode
@@ -21,9 +20,6 @@ instance showShadowRootMode :: Show ShadowRootMode where
   show Open = "open"
   show Closed = "closed"
 
-attachShadow :: ShadowRootMode -> Element -> Effect ShadowRoot
-attachShadow = _attachShadow <<< modeToProps
-
 mode :: ShadowRoot -> Maybe ShadowRootMode
 mode = modeFromString <<< _mode
 
@@ -32,13 +28,7 @@ foreign import host :: ShadowRoot -> Effect Element
 toNode :: ShadowRoot -> Node
 toNode = unsafeCoerce
 
-type ShadowRootProps = { mode :: String }
-
-foreign import _attachShadow :: ShadowRootProps -> Element -> Effect ShadowRoot
 foreign import _mode :: ShadowRoot -> String
-
-modeToProps :: ShadowRootMode -> ShadowRootProps
-modeToProps m = { mode: (show m) }
 
 modeFromString :: String -> Maybe ShadowRootMode
 modeFromString m = case m of


### PR DESCRIPTION
### Description
Basic implementation of the shadow-root functionality, as per [DOM standard](https://dom.spec.whatwg.org/#interface-shadowroot).
The function `attachShadow` is a binding to the corresponding DOM JavaScript function described
on [MDN](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM).
