### PR TITLE
Element.matches + Element.closest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Breaking changes:
 
 New features:
 - Add support for ShadowRoot API (#34)
+- Add support for `Element.matches` and `Element.closest` (#39)
 
 Bugfixes:
 

--- a/src/Web/DOM/Element.js
+++ b/src/Web/DOM/Element.js
@@ -105,6 +105,22 @@ exports.removeAttribute = function (name) {
   };
 };
 
+exports.matches = function (selector) {
+  return function(element) {
+    return function () {
+      return element.matches(selector);
+    };
+  };
+};
+
+exports._closest = function (selector) {
+  return function(element) {
+    return function () {
+      return element.closest(selector);
+    };
+  };
+};
+
 // - CSSOM ---------------------------------------------------------------------
 
 exports.scrollTop = function (node) {

--- a/src/Web/DOM/Element.purs
+++ b/src/Web/DOM/Element.purs
@@ -26,6 +26,8 @@ module Web.DOM.Element
   , getAttribute
   , hasAttribute
   , removeAttribute
+  , matches
+  , closest
   , scrollTop
   , setScrollTop
   , scrollLeft
@@ -51,7 +53,8 @@ import Web.DOM.DOMTokenList (DOMTokenList)
 import Web.DOM.Internal.Types (Element) as Exports
 import Web.DOM.Internal.Types (Element, HTMLCollection, Node)
 import Web.DOM.NonDocumentTypeChildNode (NonDocumentTypeChildNode)
-import Web.DOM.ParentNode (ParentNode)
+import Web.DOM.ParentNode (QuerySelector) as Exports
+import Web.DOM.ParentNode (ParentNode, QuerySelector)
 import Web.DOM.ShadowRoot (ShadowRoot, ShadowRootMode)
 import Web.Event.EventTarget (EventTarget)
 import Web.Internal.FFI (unsafeReadProtoTagged)
@@ -120,6 +123,13 @@ getAttribute attr = map toMaybe <<< _getAttribute attr
 foreign import _getAttribute :: String -> Element -> Effect (Nullable String)
 foreign import hasAttribute :: String -> Element -> Effect Boolean
 foreign import removeAttribute :: String -> Element -> Effect Unit
+
+foreign import matches :: QuerySelector -> Element -> Effect Boolean
+
+closest :: QuerySelector -> Element -> Effect (Maybe Element)
+closest qs = map toMaybe <<< _closest qs
+
+foreign import _closest :: QuerySelector -> Element -> Effect (Nullable Element)
 
 foreign import scrollTop :: Element -> Effect Number
 foreign import setScrollTop :: Number -> Element -> Effect Unit


### PR DESCRIPTION
fixes #38. Copied `querySelector`-isms. It's looking like perhaps `QuerySelector` doesn't make a lot of sense stuck inside `ParentNode` with this though. 🤔

**Prerequisites**

- [x] Before opening a pull request, please check the DOM standard (https://dom.spec.whatwg.org/). If it doesn't appear in this spec, it may be present in the spec for one of the other `purescript-web` projects. Although MDN is a great resource, it is not a suitable reference for this project.

https://dom.spec.whatwg.org/#dom-element-matches
https://dom.spec.whatwg.org/#dom-element-closest

**Description of the change**

Add missing Element feature

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
