### PR TITLE
`AttrName`, `ClassName`, `PropName`, and `ElementId` types. Resolves #56 and #57.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,16 @@ Notable changes to this project are documented in this file. The format is based
 ## [Unreleased]
 
 Breaking changes:
+- The `id` function returns an `ElementId` instead of a `String`. (#58 by @nsaunders)
+- The `setId` function is parameterized by `ElementId` instead of `String`. (#58 by @nsaunders)
+- The `getElementById` function is parameterized by `ElementId` instead of `String`. (#58 by @nsaunders)
+- The `className` function returns a `ClassName` instead of a `String`. (#58 by @nsaunders)
+- The `setClassName` and `getElementsByClassName` functions are parameterized by `ClassName` instead of `String`. (#58 by @nsaunders)
+- The `getAttribute`, `setAttribute`, `hasAttribute`, and `removeAttribute` functions are parameterized by `AttrName` instead of `String`. (#58 by @nsaunders)
 
 New features:
+- `AttrName`, `ClassName`, and `PropName` types have been added, migrated from [web-html](https://github.com/purescript-web/purescript-web-html). (#58 by @nsaunders)
+- A new `ElementId` type, representing the value of an `id` property/attribute, has been added. (#58 by @nsaunders)
 
 Bugfixes:
 

--- a/src/Web/DOM/Element.purs
+++ b/src/Web/DOM/Element.purs
@@ -42,11 +42,16 @@ module Web.DOM.Element
   , DOMRect
   , ShadowRootInit
   , attachShadow
+  , AttrName(..)
+  , ClassName(..)
+  , ElementId(..)
+  , PropName(..)
   ) where
 
 import Prelude
 
 import Data.Maybe (Maybe)
+import Data.Newtype (class Newtype)
 import Data.Nullable (Nullable, toMaybe, toNullable)
 import Effect (Effect)
 import Unsafe.Coerce (unsafeCoerce)
@@ -102,11 +107,11 @@ foreign import _prefix :: Element -> Nullable String
 foreign import localName :: Element -> String
 foreign import tagName :: Element -> String
 
-foreign import id :: Element -> Effect String
-foreign import setId :: String -> Element -> Effect Unit
-foreign import className :: Element -> Effect String
+foreign import id :: Element -> Effect ElementId
+foreign import setId :: ElementId -> Element -> Effect Unit
+foreign import className :: Element -> Effect ClassName
 foreign import classList :: Element -> Effect DOMTokenList
-foreign import setClassName :: String -> Element -> Effect Unit
+foreign import setClassName :: ClassName -> Element -> Effect Unit
 
 foreign import getElementsByTagName :: String -> Element -> Effect HTMLCollection
 
@@ -115,16 +120,16 @@ getElementsByTagNameNS = _getElementsByTagNameNS <<< toNullable
 
 foreign import _getElementsByTagNameNS :: Nullable String -> String -> Element -> Effect HTMLCollection
 
-foreign import getElementsByClassName :: String -> Element -> Effect HTMLCollection
+foreign import getElementsByClassName :: ClassName -> Element -> Effect HTMLCollection
 
-foreign import setAttribute :: String -> String -> Element -> Effect Unit
+foreign import setAttribute :: AttrName -> String -> Element -> Effect Unit
 
-getAttribute :: String -> Element -> Effect (Maybe String)
+getAttribute :: AttrName -> Element -> Effect (Maybe String)
 getAttribute attr = map toMaybe <<< _getAttribute attr
 
-foreign import _getAttribute :: String -> Element -> Effect (Nullable String)
-foreign import hasAttribute :: String -> Element -> Effect Boolean
-foreign import removeAttribute :: String -> Element -> Effect Unit
+foreign import _getAttribute :: AttrName -> Element -> Effect (Nullable String)
+foreign import hasAttribute :: AttrName -> Element -> Effect Boolean
+foreign import removeAttribute :: AttrName -> Element -> Effect Unit
 
 foreign import matches :: QuerySelector -> Element -> Effect Boolean
 
@@ -179,3 +184,35 @@ initToProps init = {
 }
 
 foreign import _attachShadow :: ShadowRootProps -> Element -> Effect ShadowRoot
+
+-- | A wrapper for property names.
+-- |
+-- | The phantom type `value` describes the type of value which this property
+-- | requires.
+newtype PropName :: Type -> Type
+newtype PropName value = PropName String
+
+derive instance newtypePropName :: Newtype (PropName value) _
+derive newtype instance eqPropName :: Eq (PropName value)
+derive newtype instance ordPropName :: Ord (PropName value)
+
+-- | A wrapper for attribute names.
+newtype AttrName = AttrName String
+
+derive instance newtypeAttrName :: Newtype AttrName _
+derive newtype instance eqAttrName :: Eq AttrName
+derive newtype instance ordAttrName :: Ord AttrName
+
+-- | A wrapper for strings which are used as CSS classes.
+newtype ClassName = ClassName String
+
+derive instance newtypeClassName :: Newtype ClassName _
+derive newtype instance eqClassName :: Eq ClassName
+derive newtype instance ordClassName :: Ord ClassName
+
+-- | A wrapper for strings which are used as element identifiers.
+newtype ElementId = ElementId String
+
+derive instance newtypeElementId :: Newtype ElementId _
+derive newtype instance eqElementId :: Eq ElementId
+derive newtype instance ordElementId :: Ord ElementId

--- a/src/Web/DOM/NonElementParentNode.purs
+++ b/src/Web/DOM/NonElementParentNode.purs
@@ -8,13 +8,13 @@ import Prelude
 import Data.Maybe (Maybe)
 import Data.Nullable (Nullable, toMaybe)
 import Effect (Effect)
-import Web.DOM.Element (Element)
+import Web.DOM.Element (Element, ElementId)
 
 foreign import data NonElementParentNode :: Type
 
 -- | The first element within node's descendants with a matching ID, or null if
 -- | no such element exists.
-foreign import _getElementById :: String -> NonElementParentNode -> Effect (Nullable Element)
+foreign import _getElementById :: ElementId -> NonElementParentNode -> Effect (Nullable Element)
 
-getElementById :: String -> NonElementParentNode -> Effect (Maybe Element)
+getElementById :: ElementId -> NonElementParentNode -> Effect (Maybe Element)
 getElementById eid = map toMaybe <<< _getElementById eid


### PR DESCRIPTION
**Prerequisites**

- [x] Before opening a pull request, please check the DOM standard (https://dom.spec.whatwg.org/). If it doesn't appear in this spec, it may be present in the spec for one of the other `purescript-web` projects. Although MDN is a great resource, it is not a suitable reference for this project.

**Description of the change**

With this change, the `AttrName`, `ClassName`, and `PropName` types are migrated from [web-html](https://github.com/purescript-web/purescript-web-html). A few relevant functions are also updated to use these instead of strings. (This wasn't possible before because web-html depends on web-dom, not the other way around.) See #56 for the original change request.

Similar to the types above, a new `ElementId` type represents the value of an `id` attribute/property, and the `id` and `setId` functions are updated accordingly. This resolves #57.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [ ] ~~Added a test for the contribution (if applicable)~~ N/A
